### PR TITLE
Split out config for more types

### DIFF
--- a/Kiki-HealthMultiplier/config/config.json
+++ b/Kiki-HealthMultiplier/config/config.json
@@ -16,7 +16,7 @@
 		"if bodyPartMode.enabled is false": "then",
 		"healthMultiplier": 1
 	},
-	
+
 	"PMC": {
 		"enabled": false,
 		"bodyPartMode": {
@@ -65,7 +65,7 @@
 		"healthMultiplier": 1
 	},
 
-	"Rougue": {
+	"Rogue": {
 		"enabled": false,
 		"bodyPartMode": {
 			"enabled": false,

--- a/Kiki-HealthMultiplier/config/config.json
+++ b/Kiki-HealthMultiplier/config/config.json
@@ -1,7 +1,71 @@
 {
 	"AllEqualToPlayer": false,
 
-	"AI": {
+	"Player": {
+		"enabled": true,
+		"bodyPartMode": {
+			"enabled": false,
+			"Head": 35,
+			"Chest": 85,
+			"Stomach": 70,
+			"LeftArm": 60,
+			"RightArm": 60,
+			"LeftLeg": 65,
+			"RightLeg": 65
+		},
+		"if bodyPartMode.enabled is false": "then",
+		"healthMultiplier": 1
+	},
+	
+	"PMC": {
+		"enabled": false,
+		"bodyPartMode": {
+			"enabled": false,
+			"Head": 35,
+			"Chest": 85,
+			"Stomach": 70,
+			"LeftArm": 60,
+			"RightArm": 60,
+			"LeftLeg": 65,
+			"RightLeg": 65
+		},
+		"If BodyPartMode.Enabled is false": "then",
+		"healthMultiplier": 1
+	},
+
+	"Scav": {
+		"enabled": false,
+		"bodyPartMode": {
+			"enabled": false,
+			"Head": 35,
+			"Chest": 85,
+			"Stomach": 70,
+			"LeftArm": 60,
+			"RightArm": 60,
+			"LeftLeg": 65,
+			"RightLeg": 65
+		},
+		"If BodyPartMode.Enabled is false": "then",
+		"healthMultiplier": 1
+	},
+
+	"Raider": {
+		"enabled": false,
+		"bodyPartMode": {
+			"enabled": false,
+			"Head": 35,
+			"Chest": 85,
+			"Stomach": 70,
+			"LeftArm": 60,
+			"RightArm": 60,
+			"LeftLeg": 65,
+			"RightLeg": 65
+		},
+		"If BodyPartMode.Enabled is false": "then",
+		"healthMultiplier": 1
+	},
+
+	"Rougue": {
 		"enabled": false,
 		"bodyPartMode": {
 			"enabled": false,
@@ -29,12 +93,12 @@
 			"LeftLeg": 65,
 			"RightLeg": 65
 		},
-		"if bodyPartMode.enabled is false": "then",
+		"If BodyPartMode.Enabled is false": "then",
 		"healthMultiplier": 1
 	},
 
-	"Player": {
-		"enabled": true,
+	"Follower": {
+		"enabled": false,
 		"bodyPartMode": {
 			"enabled": false,
 			"Head": 35,

--- a/Kiki-HealthMultiplier/src/healthMultiplier.js
+++ b/Kiki-HealthMultiplier/src/healthMultiplier.js
@@ -1,7 +1,6 @@
 "use strict"
 
 const CONFIG = require("../config/config.json")
-const BOTTYPES = DatabaseServer.tables.bots.types
 const PHEALTH = DatabaseServer.tables.globals.config.Health.ProfileHealthSettings.BodyPartsSettings
 
 class HealthMultiplier {
@@ -13,6 +12,7 @@ class HealthMultiplier {
 		let scavData = ProfileController.getScavProfile(CONFIG.playerId)
 
 		var setProfileHealth = function(target) {
+
 			if (target.Health) {
 				let profileParts = target.Health.BodyParts
 
@@ -38,13 +38,13 @@ class HealthMultiplier {
 
 		setProfileHealth(pmcData)
 		setProfileHealth(scavData)
-		
+
 		return output
 	}
 
 	static onLoadMod() {
 
-		var setHealth = function (bot, target, bodyPartMode) {
+		var setBotHealth = function (bot, target, bodyPartMode) {
 
 			for (let eachPart in bot) {
 
@@ -59,10 +59,12 @@ class HealthMultiplier {
 			}
 		}
 
-		for (let eachBot in BOTTYPES) {
+		const botTypes = DatabaseServer.tables.bots.types
+		
+		for (let eachBot in botTypes) {
 
-			for (let eachHPSet in BOTTYPES[eachBot].health.BodyParts) {
-				let thisBot = BOTTYPES[eachBot].health.BodyParts[eachHPSet]
+			for (let eachHPSet in botTypes[eachBot].health.BodyParts) {
+				let thisBot = botTypes[eachBot].health.BodyParts[eachHPSet]
 
 				if (CONFIG.AllEqualToPlayer == true) {
 
@@ -79,11 +81,21 @@ class HealthMultiplier {
 					}
 
 				} else {
-					let isBoss = BOTTYPES[eachBot].experience.reward.min >= 1000 ? "Boss" : "AI"
-					let mode = isBoss == "Boss" ? CONFIG.Boss.bodyPartMode.enabled : CONFIG.AI.bodyPartMode.enabled
+
+					var dict = function(input) {
+						return input === "bosstest" || input === "test" ? "PMC" :
+							input === "assault" || input === "marksman" ? "Scav"  :
+							input === "pmcbot" ? "Raider"  :
+							input === "exusec" ? "Rougue" :
+							botTypes[input].experience.reward.min >= 1000 ? "Boss" : 
+							"Follower"
+					}
+
+					let isBoss = dict(eachBot)
+					let mode = CONFIG[isBoss].bodyPartMode.enabled
 
 					if (CONFIG[isBoss].enabled == true) {
-						setHealth(thisBot, isBoss, mode)
+						setBotHealth(thisBot, isBoss, mode)
 					}
 				}
 			}

--- a/Kiki-HealthMultiplier/src/healthMultiplier.js
+++ b/Kiki-HealthMultiplier/src/healthMultiplier.js
@@ -86,7 +86,7 @@ class HealthMultiplier {
 						return input === "bosstest" || input === "test" ? "PMC" :
 							input === "assault" || input === "marksman" ? "Scav"  :
 							input === "pmcbot" ? "Raider"  :
-							input === "exusec" ? "Rougue" :
+							input === "exusec" ? "Rogue" :
 							botTypes[input].experience.reward.min >= 1000 ? "Boss" : 
 							"Follower"
 					}


### PR DESCRIPTION
Increased the bot types available in the config to Scav, PMC, Raider, Rogue, Boss and Follower (instead of Boss and AI) to give much more control.